### PR TITLE
feat: add inline edit for transaction notes

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -934,6 +934,14 @@ export function setupIpcHandlers(ipcMain: IpcMain, dialog: Dialog): void {
     return true;
   });
 
+  ipcMain.handle('update-notes', async (_, id: string, notes: string) => {
+    const db = getDatabase();
+    const now = new Date().toISOString();
+    db.run('UPDATE transactions SET notes = ?, updated_at = ? WHERE id = ?', [notes || null, now, id]);
+    saveDatabase();
+    return true;
+  });
+
   ipcMain.handle('delete-transaction', async (_, id: string) => {
     const db = getDatabase();
     db.run('DELETE FROM transactions WHERE id = ?', [id]);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -10,6 +10,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getDuplicateTransactions: (): Promise<DuplicateReviewItem[]> => ipcRenderer.invoke('get-duplicate-transactions'),
   resolveDuplicate: (id: string, action: 'keep' | 'merge') => ipcRenderer.invoke('resolve-duplicate', id, action),
   updateCategory: (id: string, category: string) => ipcRenderer.invoke('update-category', id, category),
+  updateNotes: (id: string, notes: string) => ipcRenderer.invoke('update-notes', id, notes),
   deleteTransaction: (id: string) => ipcRenderer.invoke('delete-transaction', id),
   exportCSV: () => ipcRenderer.invoke('export-csv'),
   exportExcel: () => ipcRenderer.invoke('export-excel'),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -34,6 +34,7 @@ declare global {
       getDuplicateTransactions: () => Promise<DuplicateReviewItem[]>;
       resolveDuplicate: (id: string, action: 'keep' | 'merge') => Promise<boolean>;
       updateCategory: (id: string, category: string) => Promise<boolean>;
+      updateNotes: (id: string, notes: string) => Promise<boolean>;
       deleteTransaction: (id: string) => Promise<boolean>;
       exportCSV: () => Promise<string | null>;
       exportExcel: () => Promise<string | null>;

--- a/src/renderer/pages/Transactions.tsx
+++ b/src/renderer/pages/Transactions.tsx
@@ -49,6 +49,9 @@ export default function Transactions({ locationSearch, onReplaceSearch }: Transa
   const [sortBy, setSortBy] = useState<TransactionSortBy>('date');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
   const requestIdRef = useRef(0);
+  const [editableNotes, setEditableNotes] = useState<string | null>(null);
+  const [tempNotes, setTempNotes] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
   const [filter, setFilter] = useState<FilterState>({
     startDate: '',
     endDate: '',
@@ -140,6 +143,32 @@ export default function Transactions({ locationSearch, onReplaceSearch }: Transa
   const handleCategoryChange = async (id: string, category: string) => {
     await window.electronAPI.updateCategory(id, category);
     await loadTransactions();
+  };
+
+  const startEditNotes = (id: string, currentNotes: string | null | undefined) => {
+    setEditableNotes(id);
+    setTempNotes(currentNotes || '');
+    setTimeout(() => inputRef.current?.focus(), 0);
+  };
+
+  const cancelEditNotes = () => {
+    setEditableNotes(null);
+    setTempNotes('');
+  };
+
+  const saveNotes = async (id: string) => {
+    await window.electronAPI.updateNotes(id, tempNotes);
+    setEditableNotes(null);
+    setTempNotes('');
+    await loadTransactions();
+  };
+
+  const handleNotesKeyDown = (e: React.KeyboardEvent, id: string) => {
+    if (e.key === 'Enter') {
+      saveNotes(id);
+    } else if (e.key === 'Escape') {
+      cancelEditNotes();
+    }
   };
 
   const handleDelete = async (id: string) => {
@@ -358,7 +387,21 @@ export default function Transactions({ locationSearch, onReplaceSearch }: Transa
                 </td>
                 <td>{txn.counterparty || '-'}</td>
                 <td>{txn.description || '-'}</td>
-                <td>{txn.notes || '-'}</td>
+                <td onClick={() => startEditNotes(txn.id, txn.notes)}>
+                  {editableNotes === txn.id ? (
+                    <input
+                      ref={inputRef}
+                      className="notes-input"
+                      value={tempNotes}
+                      onChange={(e) => setTempNotes(e.target.value)}
+                      onBlur={() => saveNotes(txn.id)}
+                      onKeyDown={(e) => handleNotesKeyDown(e, txn.id)}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  ) : (
+                    <span className="editable-notes">{txn.notes || '-'}</span>
+                  )}
+                </td>
                 <td>
                   <select value={txn.category || '其他'} onChange={(e) => handleCategoryChange(txn.id, e.target.value)}>
                     {Object.keys(CATEGORIES).map((cat) => (

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -1035,3 +1035,31 @@ select {
   border-radius: 8px;
   display: inline-block;
 }
+
+/* Inline Edit - Notes */
+.editable-notes {
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background-color var(--transition-fast);
+}
+
+.editable-notes:hover {
+  background-color: var(--primary-light);
+}
+
+.notes-input {
+  width: 100%;
+  padding: 4px 8px;
+  border: 2px solid var(--primary);
+  border-radius: 4px;
+  font-size: inherit;
+  font-family: inherit;
+  outline: none;
+  background: white;
+  min-width: 80px;
+}
+
+.notes-input:focus {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}


### PR DESCRIPTION
## Summary

Add inline editing capability for the notes column in Transactions page.

## Changes

- Click notes cell to edit inline
- Press Enter to save, Escape to cancel
- Added edit states and handlers in Transactions.tsx
- Added CSS styling for editable notes

## Testing

- [x] Build passes
- [ ] Manual test: click notes cell, edit, save
- [ ] Manual test: Escape cancels edit
- [ ] Manual test: Empty notes saves correctly