### PR TITLE
feat: 智能分摊功能 - ML 账单分配

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,9 @@ import { parseAlipay } from './parsers/alipay';
 import { parseBank } from './parsers/bank';
 import { parseWechat } from './parsers/wechat';
 import { parseYunshanfu } from './parsers/yunshanfu';
+import { parsePdfBill } from './parsers/pdf';
+import { parseHtmlBill } from './parsers/html';
+import { parseImageBillWithOcr } from './parsers/ocr';
 import { type DuplicateType, type Transaction, type TransactionSource } from './shared/types';
 
 type DbRow = Record<string, unknown>;
@@ -88,6 +91,14 @@ async function openDatabase(): Promise<{ db: any; dbPath: string }> {
     )
   `);
 
+  db.run(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT,
+      updated_at TEXT NOT NULL
+    )
+  `);
+
   db.run('CREATE INDEX IF NOT EXISTS idx_transactions_date ON transactions(date)');
   db.run('CREATE INDEX IF NOT EXISTS idx_transactions_category ON transactions(category)');
   db.run('CREATE INDEX IF NOT EXISTS idx_transactions_source ON transactions(source)');
@@ -129,6 +140,39 @@ function closeDatabase(db: any, dbPath: string): void {
   db.close();
 }
 
+// Settings functions
+function getSetting(db: any, key: string): string | null {
+  const stmt = db.prepare('SELECT value FROM settings WHERE key = ?');
+  stmt.bind([key]);
+  let value: string | null = null;
+  if (stmt.step()) {
+    const row = stmt.getAsObject() as { value?: string | null };
+    value = row.value ?? null;
+  }
+  stmt.free();
+  return value;
+}
+
+function setSetting(db: any, key: string, value: string): void {
+  const now = new Date().toISOString();
+  db.run(
+    `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = ?, updated_at = ?`,
+    [key, value, now, value, now]
+  );
+}
+
+function getAllSettings(db: any): Record<string, string> {
+  const stmt = db.prepare('SELECT key, value FROM settings');
+  const settings: Record<string, string> = {};
+  while (stmt.step()) {
+    const row = stmt.getAsObject() as { key: string; value: string };
+    settings[row.key] = row.value;
+  }
+  stmt.free();
+  return settings;
+}
+
 function queryAll(db: any, sql: string, params: (string | number)[] = []): DbRow[] {
   const stmt = db.prepare(sql);
   stmt.bind(params);
@@ -162,6 +206,33 @@ function parseTransactionsBySource(content: string, source: TransactionSource): 
       return parseWechat(content);
     case 'yunshanfu':
       return parseYunshanfu(content);
+  }
+}
+
+async function parseTransactionsFromFile(filePath: string, source: TransactionSource): Promise<Transaction[]> {
+  const ext = path.extname(filePath).toLowerCase();
+
+  switch (ext) {
+    case '.csv': {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      return parseTransactionsBySource(content, source);
+    }
+    case '.xlsx': {
+      // Use unzip to extract the first worksheet as CSV
+      // For xlsx, we need a more complex implementation - fall back to CSV parsing
+      // This is simplified; full implementation would need xlsx parsing
+      console.log(`warn: xlsx parsing is limited in CLI, consider converting to CSV first`);
+      return [];
+    }
+    case '.pdf':
+      return parsePdfBill(filePath, source);
+    case '.html':
+    case '.htm':
+      return parseHtmlBill(filePath, source);
+    case '.png':
+      return parseImageBillWithOcr(filePath, source);
+    default:
+      throw new Error(`暂不支持的文件类型: ${ext || 'unknown'}`);
   }
 }
 
@@ -622,7 +693,7 @@ function classifyCadenceStrict(avgIntervalDays: number): 'weekly' | 'monthly' | 
 function createCsvWatcher(watchPath: string): WatcherLike {
   if (chokidar) {
     return chokidar.watch(watchPath, {
-      ignored: (inputPath: string) => path.extname(inputPath).toLowerCase() !== '.csv',
+      depth: 0, // Watch only files directly in the directory, not subdirectories
       ignoreInitial: true,
       awaitWriteFinish: {
         stabilityThreshold: 400,
@@ -696,9 +767,18 @@ program
   .option('--source <source>', '来源: alipay|wechat|yunshanfu|bank')
   .option('--watch-dir <dir>', '监听目录中的新 CSV 并自动导入')
   .action(async (file: string | undefined, options: { source?: string; watchDir?: string }) => {
-    const importOne = (db: any, dbPath: string, filePath: string, source: TransactionSource): void => {
-      const content = decodeCsvContent(fs.readFileSync(filePath));
-      const transactions = parseTransactionsBySource(content, source);
+    const importOne = async (db: any, dbPath: string, filePath: string, source: TransactionSource): Promise<void> => {
+      const ext = path.extname(filePath).toLowerCase();
+      let transactions: Transaction[];
+
+      if (ext === '.csv') {
+        const content = decodeCsvContent(fs.readFileSync(filePath));
+        transactions = parseTransactionsBySource(content, source);
+      } else {
+        // Handle other formats: xlsx, pdf, html, png
+        transactions = await parseTransactionsFromFile(filePath, source);
+      }
+
       const result = insertTransactions(db, source, filePath, transactions);
       saveDatabase(db, dbPath);
       console.log(
@@ -706,11 +786,26 @@ program
       );
     };
 
-    if (options.watchDir) {
+    if (options.watchDir || file === undefined) {
+      // Check for default watch_dir setting if not provided
+      let watchDir = options.watchDir;
+      if (!watchDir) {
+        const { db: settingsDb } = await openDatabase();
+        const defaultWatchDir = getSetting(settingsDb, 'watch_dir');
+        settingsDb.close();
+        if (defaultWatchDir) {
+          watchDir = defaultWatchDir;
+        }
+      }
+
+      if (!watchDir) {
+        throw new Error('请提供 --watch-dir <dir> 或设置默认监听目录: expense-cli config set watch_dir <dir>');
+      }
+
       if (file) {
         throw new Error('使用 --watch-dir 时不需要提供 <file>');
       }
-      const watchPath = path.resolve(options.watchDir);
+      const watchPath = path.resolve(watchDir);
       if (!fs.existsSync(watchPath)) {
         throw new Error(`监听目录不存在: ${watchPath}`);
       }
@@ -738,7 +833,15 @@ program
         });
       });
 
+      // Supported file extensions
+      const supportedExtensions = ['.csv', '.xlsx', '.pdf', '.html', '.htm', '.png'];
+
       watcher.on('add', (addedPath: string) => {
+        const ext = path.extname(addedPath).toLowerCase();
+        // Skip unsupported file types
+        if (!supportedExtensions.includes(ext)) {
+          return;
+        }
         queue = queue
           .then(() => {
             const source = detectSourceFromFilename(addedPath);
@@ -786,6 +889,63 @@ program
     } finally {
       db.close();
     }
+  });
+
+// Config command
+const configCmd = program
+  .command('config')
+  .description('查看和设置配置');
+
+configCmd
+  .command('get <key>')
+  .description('获取配置值')
+  .action(async (key: string) => {
+    const { db } = await openDatabase();
+    const value = getSetting(db, key);
+    db.close();
+    if (value === null) {
+      console.log(`未设置: ${key}`);
+    } else {
+      console.log(`${key}=${value}`);
+    }
+  });
+
+configCmd
+  .command('set <key> <value>')
+  .description('设置配置值')
+  .action(async (key: string, value: string) => {
+    const { db, dbPath } = await openDatabase();
+    setSetting(db, key, value);
+    saveDatabase(db, dbPath);
+    db.close();
+    console.log(`已设置: ${key}=${value}`);
+  });
+
+configCmd
+  .command('list')
+  .description('列出所有配置')
+  .action(async () => {
+    const { db } = await openDatabase();
+    const settings = getAllSettings(db);
+    db.close();
+    if (Object.keys(settings).length === 0) {
+      console.log('暂无配置');
+    } else {
+      for (const [k, v] of Object.entries(settings)) {
+        console.log(`${k}=${v}`);
+      }
+    }
+  });
+
+configCmd
+  .command('delete <key>')
+  .description('删除配置')
+  .action(async (key: string) => {
+    const { db, dbPath } = await openDatabase();
+    db.run('DELETE FROM settings WHERE key = ?', [key]);
+    saveDatabase(db, dbPath);
+    db.close();
+    console.log(`已删除: ${key}`);
   });
 
 program

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -2,7 +2,7 @@ import initSqlJs from 'sql.js';
 import path from 'path';
 import fs from 'fs';
 import { app } from 'electron';
-import { Budget, Member, Transaction } from '../shared/types';
+import { Budget, Member, Transaction, AssignmentHistory, AssignmentPattern, PredictionResult, FeatureKey, LearnAssignmentParams, ApplySmartAssignmentResult } from '../shared/types';
 
 let db: any = null;
 let dbPath: string = '';
@@ -119,6 +119,33 @@ function ensureSchema(): void {
   ensureColumn('tags', 'TEXT');
   ensureColumn('currency', 'TEXT DEFAULT "CNY"');
   ensureColumn('member_id', 'TEXT');
+
+  // Smart Assignment tables
+  database.run(`
+    CREATE TABLE IF NOT EXISTS assignment_history (
+      id TEXT PRIMARY KEY,
+      transaction_id TEXT NOT NULL,
+      member_id TEXT NOT NULL,
+      feature_key TEXT NOT NULL,
+      feature_value TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    )
+  `);
+
+  database.run(`
+    CREATE TABLE IF NOT EXISTS assignment_patterns (
+      id TEXT PRIMARY KEY,
+      feature_key TEXT NOT NULL,
+      feature_value TEXT NOT NULL,
+      member_id TEXT NOT NULL,
+      count INTEGER DEFAULT 1,
+      confidence REAL DEFAULT 0,
+      updated_at TEXT NOT NULL,
+      UNIQUE(feature_key, feature_value, member_id)
+    )
+  `);
+
+  database.run('CREATE INDEX IF NOT EXISTS idx_assignment_patterns_feature ON assignment_patterns(feature_key, feature_value)');
 
   database.run('CREATE INDEX IF NOT EXISTS idx_transactions_date ON transactions(date)');
   database.run('CREATE INDEX IF NOT EXISTS idx_transactions_category ON transactions(category)');
@@ -550,4 +577,353 @@ export function getMemberSpendingSummary(year: number, month?: number): { member
   }
   stmt.free();
   return results;
+}
+
+// Smart Assignment Functions
+
+// Extract merchant keywords from counterparty or description
+function extractMerchantKeywords(text?: string): string[] {
+  if (!text) return [];
+  
+  const cleaned = text
+    .toLowerCase()
+    .replace(/[（(【\[].*?[）)】\]]/g, ' ')
+    .replace(/\+?\d[\d\s-]{6,}\d/g, ' ')
+    .replace(/(?:地址|addr|address)[:：]?\s*[^\s,，;；]*/gi, ' ')
+    .replace(/[0-9一二三四五六七八九十百千]+(?:号|栋|幢|单元|室|楼|层)/g, ' ')
+    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+    .trim();
+
+  // Filter out location-related words
+  const locationWords = ['省', '市', '区', '县', '镇', '乡', '村', '路', '街', '巷', '道'];
+  const tokens = cleaned.split(/\s+/).filter(Boolean);
+  
+  return tokens
+    .filter(token => !locationWords.some(word => token.endsWith(word)))
+    .slice(0, 3); // Take up to 3 keywords
+}
+
+// Normalize feature value for matching
+function normalizeFeatureValue(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[\s\p{P}\p{S}]+/gu, '')
+    .trim();
+}
+
+// Extract features from a transaction
+function extractTransactionFeatures(params: LearnAssignmentParams): Array<{ key: FeatureKey; value: string }> {
+  const features: Array<{ key: FeatureKey; value: string }> = [];
+  
+  // Counterparty feature
+  if (params.counterparty && params.counterparty.trim()) {
+    features.push({
+      key: 'counterparty',
+      value: normalizeFeatureValue(params.counterparty),
+    });
+  }
+  
+  // Category feature
+  if (params.category && params.category.trim()) {
+    features.push({
+      key: 'category',
+      value: normalizeFeatureValue(params.category),
+    });
+  }
+  
+  // Description feature
+  if (params.description && params.description.trim()) {
+    features.push({
+      key: 'description',
+      value: normalizeFeatureValue(params.description),
+    });
+  }
+  
+  // Merchant keyword feature
+  const merchantText = params.counterparty || params.description || '';
+  const keywords = extractMerchantKeywords(merchantText);
+  for (const keyword of keywords) {
+    if (keyword.length >= 2) { // Skip single character keywords
+      features.push({
+        key: 'merchant_keyword',
+        value: keyword,
+      });
+    }
+  }
+  
+  return features;
+}
+
+// Learn from a manual assignment
+export function learnAssignment(params: LearnAssignmentParams): void {
+  const database = getDatabase();
+  const now = new Date().toISOString();
+  const features = extractTransactionFeatures(params);
+  
+  // Record each feature in assignment_history
+  for (const feature of features) {
+    const historyId = Date.now().toString(36) + Math.random().toString(36).slice(2);
+    database.run(
+      `INSERT INTO assignment_history (id, transaction_id, member_id, feature_key, feature_value, created_at) 
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [historyId, params.transactionId, params.memberId, feature.key, feature.value, now]
+    );
+    
+    // Update or insert pattern
+    const existingStmt = database.prepare(
+      `SELECT count FROM assignment_patterns WHERE feature_key = ? AND feature_value = ? AND member_id = ?`
+    );
+    existingStmt.bind([feature.key, feature.value, params.memberId]);
+    
+    if (existingStmt.step()) {
+      // Update existing pattern count
+      const row = existingStmt.getAsObject() as { count: number };
+      const newCount = (row.count || 0) + 1;
+      existingStmt.free();
+      
+      // Calculate total count for this feature_value across all members
+      const totalStmt = database.prepare(
+        `SELECT SUM(count) as total FROM assignment_patterns WHERE feature_key = ? AND feature_value = ?`
+      );
+      totalStmt.bind([feature.key, feature.value]);
+      let totalCount = 1;
+      if (totalStmt.step()) {
+        const totalRow = totalStmt.getAsObject() as { total: number };
+        totalCount = (totalRow.total || 1) + 1;
+      }
+      totalStmt.free();
+      
+      const confidence = newCount / totalCount;
+      
+      database.run(
+        `UPDATE assignment_patterns SET count = ?, confidence = ?, updated_at = ? 
+         WHERE feature_key = ? AND feature_value = ? AND member_id = ?`,
+        [newCount, confidence, now, feature.key, feature.value, params.memberId]
+      );
+    } else {
+      // Insert new pattern
+      existingStmt.free();
+      const patternId = Date.now().toString(36) + Math.random().toString(36).slice(2);
+      database.run(
+        `INSERT INTO assignment_patterns (id, feature_key, feature_value, member_id, count, confidence, updated_at)
+         VALUES (?, ?, ?, ?, 1, 1.0, ?)`,
+        [patternId, feature.key, feature.value, params.memberId, now]
+      );
+    }
+  }
+  
+  // Recalculate all confidences for each feature_value to ensure they sum to 1
+  recalculateConfidences(database);
+  saveDatabase();
+}
+
+// Recalculate confidences for all patterns
+function recalculateConfidences(database: any): void {
+  // Get all unique feature_key + feature_value combinations
+  const stmt = database.prepare(
+    `SELECT DISTINCT feature_key, feature_value FROM assignment_patterns`
+  );
+  
+  const featureCombinations: Array<{ feature_key: string; feature_value: string }> = [];
+  while (stmt.step()) {
+    featureCombinations.push(stmt.getAsObject() as { feature_key: string; feature_value: string });
+  }
+  stmt.free();
+  
+  for (const combo of featureCombinations) {
+    // Get total count for this feature_value
+    const totalStmt = database.prepare(
+      `SELECT SUM(count) as total FROM assignment_patterns WHERE feature_key = ? AND feature_value = ?`
+    );
+    totalStmt.bind([combo.feature_key, combo.feature_value]);
+    let totalCount = 1;
+    if (totalStmt.step()) {
+      const row = totalStmt.getAsObject() as { total: number };
+      totalCount = row.total || 1;
+    }
+    totalStmt.free();
+    
+    // Update confidences
+    const updateStmt = database.prepare(
+      `UPDATE assignment_patterns SET confidence = CAST(count AS REAL) / ? WHERE feature_key = ? AND feature_value = ?`
+    );
+    updateStmt.bind([totalCount, combo.feature_key, combo.feature_value]);
+    updateStmt.step();
+    updateStmt.free();
+  }
+}
+
+// Predict member for a single transaction
+export function predictMember(
+  transactionId: string,
+  counterparty?: string,
+  category?: string,
+  description?: string
+): PredictionResult {
+  const database = getDatabase();
+  const features = extractTransactionFeatures({ transactionId, memberId: '', counterparty, category, description });
+  
+  // Query all matching patterns
+  const matchedPatterns: Array<{
+    feature_key: string;
+    feature_value: string;
+    member_id: string;
+    confidence: number;
+    count: number;
+  }> = [];
+  
+  for (const feature of features) {
+    const stmt = database.prepare(
+      `SELECT feature_key, feature_value, member_id, confidence, count 
+       FROM assignment_patterns 
+       WHERE feature_key = ? AND feature_value = ?`
+    );
+    stmt.bind([feature.key, feature.value]);
+    
+    while (stmt.step()) {
+      matchedPatterns.push(stmt.getAsObject() as any);
+    }
+    stmt.free();
+  }
+  
+  if (matchedPatterns.length === 0) {
+    return {
+      transactionId,
+      memberId: null,
+      memberName: null,
+      confidence: 0,
+      action: 'none',
+      matchedFeatures: [],
+    };
+  }
+  
+  // Aggregate confidence by member (weighted by count)
+  const memberScores: Record<string, { confidence: number; count: number; matchedFeatures: Array<{ featureKey: FeatureKey; featureValue: string }> }> = {};
+  
+  for (const pattern of matchedPatterns) {
+    if (!memberScores[pattern.member_id]) {
+      memberScores[pattern.member_id] = { confidence: 0, count: 0, matchedFeatures: [] };
+    }
+    memberScores[pattern.member_id].confidence += pattern.confidence * pattern.count;
+    memberScores[pattern.member_id].count += pattern.count;
+    
+    // Track matched features
+    const existingFeature = memberScores[pattern.member_id].matchedFeatures.find(
+      f => f.featureKey === pattern.feature_key && f.featureValue === pattern.feature_value
+    );
+    if (!existingFeature) {
+      memberScores[pattern.member_id].matchedFeatures.push({
+        featureKey: pattern.feature_key as FeatureKey,
+        featureValue: pattern.feature_value,
+      });
+    }
+  }
+  
+  // Find member with highest weighted confidence
+  let bestMemberId: string | null = null;
+  let bestConfidence = 0;
+  let bestMatchedFeatures: Array<{ featureKey: FeatureKey; featureValue: string }> = [];
+  
+  for (const [memberId, data] of Object.entries(memberScores)) {
+    const avgConfidence = data.confidence / data.count;
+    if (avgConfidence > bestConfidence) {
+      bestConfidence = avgConfidence;
+      bestMemberId = memberId;
+      bestMatchedFeatures = data.matchedFeatures;
+    }
+  }
+  
+  // Get member name
+  let memberName: string | null = null;
+  if (bestMemberId) {
+    const memberStmt = database.prepare('SELECT name FROM members WHERE id = ?');
+    memberStmt.bind([bestMemberId]);
+    if (memberStmt.step()) {
+      const row = memberStmt.getAsObject() as { name: string };
+      memberName = row.name;
+    }
+    memberStmt.free();
+  }
+  
+  // Determine action based on confidence
+  let action: 'auto_assign' | 'suggest' | 'none';
+  if (bestConfidence >= 0.7) {
+    action = 'auto_assign';
+  } else if (bestConfidence >= 0.3) {
+    action = 'suggest';
+  } else {
+    action = 'none';
+  }
+  
+  return {
+    transactionId,
+    memberId: bestMemberId,
+    memberName,
+    confidence: bestConfidence,
+    action,
+    matchedFeatures: bestMatchedFeatures,
+  };
+}
+
+// Apply smart assignment to a list of transactions
+export function applySmartAssignment(
+  transactions: Array<{
+    id: string;
+    counterparty?: string;
+    category?: string;
+    description?: string;
+  }>
+): ApplySmartAssignmentResult {
+  const database = getDatabase();
+  const results: PredictionResult[] = [];
+  let autoAssigned = 0;
+  let suggested = 0;
+  
+  for (const txn of transactions) {
+    const prediction = predictMember(txn.id, txn.counterparty, txn.category, txn.description);
+    results.push(prediction);
+    
+    if (prediction.action === 'auto_assign' && prediction.memberId) {
+      // Auto-assign the transaction
+      const now = new Date().toISOString();
+      database.run(
+        'UPDATE transactions SET member_id = ?, updated_at = ? WHERE id = ?',
+        [prediction.memberId, now, txn.id]
+      );
+      autoAssigned += 1;
+    } else if (prediction.action === 'suggest') {
+      suggested += 1;
+    }
+  }
+  
+  saveDatabase();
+  
+  return {
+    processed: transactions.length,
+    autoAssigned,
+    suggested,
+    results,
+  };
+}
+
+// Get all learned patterns
+export function getPatterns(): AssignmentPattern[] {
+  const database = getDatabase();
+  const stmt = database.prepare(
+    `SELECT * FROM assignment_patterns ORDER BY confidence DESC, count DESC`
+  );
+  const results: AssignmentPattern[] = [];
+  while (stmt.step()) {
+    results.push(stmt.getAsObject() as unknown as AssignmentPattern);
+  }
+  stmt.free();
+  return results;
+}
+
+// Delete a pattern
+export function deletePattern(id: string): boolean {
+  const database = getDatabase();
+  database.run('DELETE FROM assignment_patterns WHERE id = ?', [id]);
+  saveDatabase();
+  return true;
 }

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -2,7 +2,7 @@ import initSqlJs from 'sql.js';
 import path from 'path';
 import fs from 'fs';
 import { app } from 'electron';
-import { Budget, Transaction } from '../shared/types';
+import { Budget, Member, Transaction } from '../shared/types';
 
 let db: any = null;
 let dbPath: string = '';
@@ -73,6 +73,24 @@ function ensureSchema(): void {
     )
   `);
 
+  database.run(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT,
+      updated_at TEXT NOT NULL
+    )
+  `);
+
+  database.run(`
+    CREATE TABLE IF NOT EXISTS members (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      color TEXT DEFAULT '#3B82F6',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
+
   const columnsStmt = database.prepare("PRAGMA table_info('transactions')");
   const existingColumns = new Set<string>();
   while (columnsStmt.step()) {
@@ -100,6 +118,7 @@ function ensureSchema(): void {
   ensureColumn('merged_with', 'TEXT');
   ensureColumn('tags', 'TEXT');
   ensureColumn('currency', 'TEXT DEFAULT "CNY"');
+  ensureColumn('member_id', 'TEXT');
 
   database.run('CREATE INDEX IF NOT EXISTS idx_transactions_date ON transactions(date)');
   database.run('CREATE INDEX IF NOT EXISTS idx_transactions_category ON transactions(category)');
@@ -397,4 +416,138 @@ export function closeDatabase(): void {
     db.close();
     db = null;
   }
+}
+
+// Settings functions
+export function getSetting(key: string): string | null {
+  const database = getDatabase();
+  const stmt = database.prepare('SELECT value FROM settings WHERE key = ?');
+  stmt.bind([key]);
+  let value: string | null = null;
+  if (stmt.step()) {
+    const row = stmt.getAsObject() as { value?: string | null };
+    value = row.value ?? null;
+  }
+  stmt.free();
+  return value;
+}
+
+export function setSetting(key: string, value: string): void {
+  const database = getDatabase();
+  const now = new Date().toISOString();
+  database.run(
+    `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = ?, updated_at = ?`,
+    [key, value, now, value, now]
+  );
+  saveDatabase();
+}
+
+export function getAllSettings(): Record<string, string> {
+  const database = getDatabase();
+  const stmt = database.prepare('SELECT key, value FROM settings');
+  const settings: Record<string, string> = {};
+  while (stmt.step()) {
+    const row = stmt.getAsObject() as { key: string; value: string };
+    settings[row.key] = row.value;
+  }
+  stmt.free();
+  return settings;
+}
+
+// Member functions
+export function getMembers(): Member[] {
+  const database = getDatabase();
+  const stmt = database.prepare('SELECT * FROM members ORDER BY name ASC');
+  const results: Member[] = [];
+  while (stmt.step()) {
+    results.push(stmt.getAsObject() as unknown as Member);
+  }
+  stmt.free();
+  return results;
+}
+
+export function addMember(id: string, name: string, color: string): void {
+  const database = getDatabase();
+  const now = new Date().toISOString();
+  database.run(
+    'INSERT INTO members (id, name, color, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [id, name, color || '#3B82F6', now, now]
+  );
+  saveDatabase();
+}
+
+export function updateMember(id: string, name: string, color: string): void {
+  const database = getDatabase();
+  const now = new Date().toISOString();
+  database.run(
+    'UPDATE members SET name = ?, color = ?, updated_at = ? WHERE id = ?',
+    [name, color || '#3B82F6', now, id]
+  );
+  saveDatabase();
+}
+
+export function deleteMember(id: string): void {
+  const database = getDatabase();
+  // First, update transactions to remove member_id reference
+  database.run('UPDATE transactions SET member_id = NULL WHERE member_id = ?', [id]);
+  // Then delete the member
+  database.run('DELETE FROM members WHERE id = ?', [id]);
+  saveDatabase();
+}
+
+export function setTransactionMember(transactionId: string, memberId: string | null): void {
+  const database = getDatabase();
+  const now = new Date().toISOString();
+  if (memberId === null) {
+    database.run('UPDATE transactions SET member_id = NULL, updated_at = ? WHERE id = ?', [now, transactionId]);
+  } else {
+    database.run('UPDATE transactions SET member_id = ?, updated_at = ? WHERE id = ?', [memberId, now, transactionId]);
+  }
+  saveDatabase();
+}
+
+export function getMemberSpendingSummary(year: number, month?: number): { memberId: string; memberName: string; memberColor: string; total: number }[] {
+  const database = getDatabase();
+  
+  let dateFilter: string;
+  let params: (string | number)[];
+  
+  if (month !== undefined) {
+    const monthStr = String(month).padStart(2, '0');
+    dateFilter = `strftime('%Y-%m', date) = ?`;
+    params = [`${year}-${monthStr}`];
+  } else {
+    dateFilter = `strftime('%Y', date) = ?`;
+    params = [String(year)];
+  }
+
+  const sql = `
+    SELECT 
+      m.id as memberId,
+      m.name as memberName,
+      m.color as memberColor,
+      COALESCE(SUM(t.amount), 0) as total
+    FROM members m
+    LEFT JOIN transactions t ON m.id = t.member_id 
+      AND t.type = 'expense'
+      AND ${dateFilter}
+    GROUP BY m.id
+    ORDER BY total DESC
+  `;
+  
+  const stmt = database.prepare(sql);
+  stmt.bind(params);
+  const results: { memberId: string; memberName: string; memberColor: string; total: number }[] = [];
+  while (stmt.step()) {
+    const row = stmt.getAsObject() as { memberId: string; memberName: string; memberColor: string; total: number };
+    results.push({
+      memberId: row.memberId,
+      memberName: row.memberName,
+      memberColor: row.memberColor,
+      total: Number(row.total),
+    });
+  }
+  stmt.free();
+  return results;
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -5,7 +5,7 @@ import { execFileSync } from 'child_process';
 import { TextDecoder } from 'util';
 import Papa from 'papaparse';
 import { Dialog, IpcMain } from 'electron';
-import { getDatabase, getDatabasePath, deleteBudget, getBudgets, getBudgetSpending, insertTransactions, saveDatabase, setBudget, getTransactionTags, addTransactionTag, removeTransactionTag, updateTransactionCurrency, getMembers, addMember, updateMember, deleteMember, setTransactionMember, getMemberSpendingSummary } from './database';
+import { getDatabase, getDatabasePath, deleteBudget, getBudgets, getBudgetSpending, insertTransactions, saveDatabase, setBudget, getTransactionTags, addTransactionTag, removeTransactionTag, updateTransactionCurrency, getMembers, addMember, updateMember, deleteMember, setTransactionMember, getMemberSpendingSummary, learnAssignment, predictMember, applySmartAssignment, getPatterns, deletePattern } from './database';
 import { parseAlipay } from '../parsers/alipay';
 import { parseBank } from '../parsers/bank';
 import { parseWechat } from '../parsers/wechat';
@@ -13,7 +13,7 @@ import { parseYunshanfu } from '../parsers/yunshanfu';
 import { parsePdfBill } from '../parsers/pdf';
 import { parseHtmlBill } from '../parsers/html';
 import { parseImageBillWithOcr } from '../parsers/ocr';
-import { Budget, BudgetAlert, DuplicateReviewItem, DuplicateType, Member, Summary, SummaryQuery, Transaction, TransactionListResponse, TransactionQuery, TransactionSource } from '../shared/types';
+import { Budget, BudgetAlert, DuplicateReviewItem, DuplicateType, Member, Summary, SummaryQuery, Transaction, TransactionListResponse, TransactionQuery, TransactionSource, PredictionResult, ApplySmartAssignmentResult, AssignmentPattern } from '../shared/types';
 import { buildTransactionWhereClause } from './ipcFilters';
 
 type Source = TransactionSource;
@@ -23,6 +23,7 @@ interface ImportCsvOptions {
   dryRun?: boolean;
   previewLimit?: number;
   currency?: string;
+  applySmartAssignment?: boolean;
 }
 
 interface ImportCsvResult {
@@ -38,6 +39,7 @@ interface ImportCsvResult {
   preview: Array<Pick<Transaction, 'date' | 'type' | 'amount' | 'counterparty' | 'description' | 'category'>>;
   columns?: string[];
   columnMapping?: Record<string, string>;
+  smartAssignment?: ApplySmartAssignmentResult;
 }
 
 interface DuplicateCandidate {
@@ -818,6 +820,17 @@ export function setupIpcHandlers(ipcMain: IpcMain, dialog: Dialog): void {
       linkRefundTransactions(importId);
       saveDatabase();
 
+      // Apply smart assignment if enabled
+      if (options?.applySmartAssignment && result.inserted > 0) {
+        const smartAssignmentTxns = toInsert.map(txn => ({
+          id: txn.id,
+          counterparty: txn.counterparty,
+          category: txn.category,
+          description: txn.description,
+        }));
+        result.smartAssignment = applySmartAssignment(smartAssignmentTxns);
+      }
+
       result.importId = importId;
       return result;
     } catch (error) {
@@ -1282,10 +1295,69 @@ export function setupIpcHandlers(ipcMain: IpcMain, dialog: Dialog): void {
   });
 
   ipcMain.handle('set-transaction-member', async (_, transactionId: string, memberId: string | null): Promise<void> => {
+    // Get transaction details for learning
+    let counterparty: string | undefined;
+    let category: string | undefined;
+    let description: string | undefined;
+    
+    if (memberId) {
+      const db = getDatabase();
+      const stmt = db.prepare('SELECT counterparty, category, description FROM transactions WHERE id = ?');
+      stmt.bind([transactionId]);
+      if (stmt.step()) {
+        const row = stmt.getAsObject() as { counterparty?: string; category?: string; description?: string };
+        counterparty = row.counterparty;
+        category = row.category;
+        description = row.description;
+      }
+      stmt.free();
+      
+      // Learn from this assignment
+      learnAssignment({
+        transactionId,
+        memberId,
+        counterparty,
+        category,
+        description,
+      });
+    }
+    
     setTransactionMember(transactionId, memberId);
   });
 
   ipcMain.handle('get-member-summary', async (_, year: number, month?: number): Promise<{ memberId: string; memberName: string; memberColor: string; total: number }[]> => {
     return getMemberSpendingSummary(year, month);
+  });
+
+  // Smart Assignment handlers
+  ipcMain.handle('learn-assignment', async (_, params: {
+    transactionId: string;
+    memberId: string;
+    counterparty?: string;
+    category?: string;
+    description?: string;
+  }): Promise<void> => {
+    learnAssignment(params);
+  });
+
+  ipcMain.handle('predict-member', async (_, transactionId: string, counterparty?: string, category?: string, description?: string) => {
+    return predictMember(transactionId, counterparty, category, description);
+  });
+
+  ipcMain.handle('apply-smart-assignment', async (_, transactions: Array<{
+    id: string;
+    counterparty?: string;
+    category?: string;
+    description?: string;
+  }>) => {
+    return applySmartAssignment(transactions);
+  });
+
+  ipcMain.handle('get-patterns', async () => {
+    return getPatterns();
+  });
+
+  ipcMain.handle('delete-pattern', async (_, id: string): Promise<boolean> => {
+    return deletePattern(id);
   });
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -5,7 +5,7 @@ import { execFileSync } from 'child_process';
 import { TextDecoder } from 'util';
 import Papa from 'papaparse';
 import { Dialog, IpcMain } from 'electron';
-import { getDatabase, getDatabasePath, deleteBudget, getBudgets, getBudgetSpending, insertTransactions, saveDatabase, setBudget, getTransactionTags, addTransactionTag, removeTransactionTag, updateTransactionCurrency } from './database';
+import { getDatabase, getDatabasePath, deleteBudget, getBudgets, getBudgetSpending, insertTransactions, saveDatabase, setBudget, getTransactionTags, addTransactionTag, removeTransactionTag, updateTransactionCurrency, getMembers, addMember, updateMember, deleteMember, setTransactionMember, getMemberSpendingSummary } from './database';
 import { parseAlipay } from '../parsers/alipay';
 import { parseBank } from '../parsers/bank';
 import { parseWechat } from '../parsers/wechat';
@@ -13,7 +13,7 @@ import { parseYunshanfu } from '../parsers/yunshanfu';
 import { parsePdfBill } from '../parsers/pdf';
 import { parseHtmlBill } from '../parsers/html';
 import { parseImageBillWithOcr } from '../parsers/ocr';
-import { Budget, BudgetAlert, DuplicateReviewItem, DuplicateType, Summary, SummaryQuery, Transaction, TransactionListResponse, TransactionQuery, TransactionSource } from '../shared/types';
+import { Budget, BudgetAlert, DuplicateReviewItem, DuplicateType, Member, Summary, SummaryQuery, Transaction, TransactionListResponse, TransactionQuery, TransactionSource } from '../shared/types';
 import { buildTransactionWhereClause } from './ipcFilters';
 
 type Source = TransactionSource;
@@ -1049,6 +1049,7 @@ export function setupIpcHandlers(ipcMain: IpcMain, dialog: Dialog): void {
       monthly,
       byCategory,
       topMerchants,
+      byMember: getMemberSpendingSummary(targetYear),
       availableYears: availableYears.length > 0 ? availableYears : [currentYear],
     };
   });
@@ -1261,5 +1262,30 @@ export function setupIpcHandlers(ipcMain: IpcMain, dialog: Dialog): void {
       currentMonth,
       previousMonth,
     };
+  });
+
+  // Member handlers
+  ipcMain.handle('get-members', async (): Promise<Member[]> => {
+    return getMembers();
+  });
+
+  ipcMain.handle('add-member', async (_, id: string, name: string, color: string): Promise<void> => {
+    addMember(id, name, color);
+  });
+
+  ipcMain.handle('update-member', async (_, id: string, name: string, color: string): Promise<void> => {
+    updateMember(id, name, color);
+  });
+
+  ipcMain.handle('delete-member', async (_, id: string): Promise<void> => {
+    deleteMember(id);
+  });
+
+  ipcMain.handle('set-transaction-member', async (_, transactionId: string, memberId: string | null): Promise<void> => {
+    setTransactionMember(transactionId, memberId);
+  });
+
+  ipcMain.handle('get-member-summary', async (_, year: number, month?: number): Promise<{ memberId: string; memberName: string; memberColor: string; total: number }[]> => {
+    return getMemberSpendingSummary(year, month);
   });
 }

--- a/src/main/ipcFilters.ts
+++ b/src/main/ipcFilters.ts
@@ -35,6 +35,10 @@ export function buildTransactionWhereClause(filters?: TransactionQuery): { where
   if (filters?.refundOnly) {
     where.push('COALESCE(is_refund, 0) = 1');
   }
+  if (filters?.memberId) {
+    where.push('member_id = ?');
+    params.push(filters.memberId);
+  }
   if (filters?.q) {
     where.push('(description LIKE ? OR counterparty LIKE ? OR notes LIKE ?)');
     const keyword = `%${filters.q}%`;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
-import { Budget, BudgetAlert, DuplicateReviewItem, Summary, SummaryQuery, Transaction, TransactionListResponse, TransactionQuery } from '../shared/types';
+import { Budget, BudgetAlert, DuplicateReviewItem, Member, Summary, SummaryQuery, Transaction, TransactionListResponse, TransactionQuery } from '../shared/types';
 import { AppPage, buildDrilldownQuery, parseHashLocation } from '../shared/drilldown';
 import Dashboard from './pages/Dashboard';
 import Import from './pages/Import';
 import Transactions from './pages/Transactions';
 import Budgets from './pages/Budgets';
+import Members from './pages/Members';
 
 declare global {
   interface Window {
@@ -47,6 +48,12 @@ declare global {
       getTags: (id: string) => Promise<string[]>;
       addTag: (id: string, tag: string) => Promise<boolean>;
       removeTag: (id: string, tag: string) => Promise<boolean>;
+      getMembers: () => Promise<Member[]>;
+      addMember: (id: string, name: string, color: string) => Promise<void>;
+      updateMember: (id: string, name: string, color: string) => Promise<void>;
+      deleteMember: (id: string) => Promise<void>;
+      setTransactionMember: (transactionId: string, memberId: string | null) => Promise<void>;
+      getMemberSummary: (year: number, month?: number) => Promise<{ memberId: string; memberName: string; memberColor: string; total: number }[]>;
     };
   }
 }
@@ -54,6 +61,7 @@ declare global {
 const navItems = [
   { page: 'dashboard', label: '仪表盘', icon: '📊' },
   { page: 'budgets', label: '预算', icon: '💵' },
+  { page: 'members', label: '成员', icon: '👨‍👩‍👧‍👦' },
   { page: 'import', label: '导入', icon: '📥' },
   { page: 'transactions', label: '交易记录', icon: '📋' },
 ] as const;
@@ -107,6 +115,7 @@ export default function App() {
           />
         )}
         {currentPage === 'budgets' && <Budgets />}
+        {currentPage === 'members' && <Members locationSearch={locationState.search} />}
         {currentPage === 'import' && <Import />}
         {currentPage === 'transactions' && (
           <Transactions

--- a/src/renderer/pages/Dashboard.tsx
+++ b/src/renderer/pages/Dashboard.tsx
@@ -147,6 +147,16 @@ export default function Dashboard({ onDrilldown }: DashboardProps) {
     [summary]
   );
 
+  const memberData = useMemo(
+    () =>
+      (summary?.byMember ?? []).map((item) => ({
+        name: item.memberName,
+        value: item.total,
+        color: item.memberColor,
+      })),
+    [summary]
+  );
+
   if (loading && !summary) return <div>加载中...</div>;
   if (!summary) return <div>暂无数据</div>;
 
@@ -356,6 +366,29 @@ export default function Dashboard({ onDrilldown }: DashboardProps) {
           </ResponsiveContainer>
         )}
       </div>
+
+      {memberData.length > 0 && (
+        <div className="chart-container">
+          <div className="chart-header">
+            <h3 className="chart-title">👥 成员支出统计</h3>
+            <span className="chart-subtitle">各成员支出占比</span>
+          </div>
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={memberData} layout="vertical" margin={{ top: 20, right: 30, left: 80, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis type="number" />
+              <YAxis type="category" dataKey="name" width={70} />
+              <Tooltip formatter={(value: number) => formatCurrency(value)} />
+              <Legend />
+              <Bar dataKey="value" name="支出" radius={[0, 4, 4, 0]}>
+                {memberData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.color} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
 
       <div className="card">
         <div className="card-header">

--- a/src/renderer/pages/Members.tsx
+++ b/src/renderer/pages/Members.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useState } from 'react';
+import { Member } from '../../shared/types';
+
+interface MembersProps {
+  locationSearch: string;
+}
+
+const MEMBER_COLORS = [
+  '#3B82F6', // blue
+  '#10B981', // green
+  '#EF4444', // red
+  '#8B5CF6', // purple
+  '#F59E0B', // orange
+  '#EC4899', // pink
+  '#14B8A6', // teal
+  '#6366F1', // indigo
+];
+
+export default function Members({ locationSearch }: MembersProps) {
+  const [members, setMembers] = useState<Member[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingMember, setEditingMember] = useState<Member | null>(null);
+  const [newName, setNewName] = useState('');
+  const [newColor, setNewColor] = useState(MEMBER_COLORS[0]);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+
+  const loadMembers = async () => {
+    try {
+      const data = await window.electronAPI.getMembers();
+      setMembers(data);
+    } catch (error) {
+      console.error('Failed to load members:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadMembers();
+  }, []);
+
+  const handleAddMember = async () => {
+    if (!newName.trim()) return;
+    
+    const id = Date.now().toString(36) + Math.random().toString(36).slice(2);
+    await window.electronAPI.addMember(id, newName.trim(), newColor);
+    
+    setNewName('');
+    setNewColor(MEMBER_COLORS[0]);
+    setShowAddForm(false);
+    await loadMembers();
+  };
+
+  const handleUpdateMember = async () => {
+    if (!editingMember || !newName.trim()) return;
+    
+    await window.electronAPI.updateMember(editingMember.id, newName.trim(), newColor);
+    
+    setEditingMember(null);
+    setNewName('');
+    setNewColor(MEMBER_COLORS[0]);
+    await loadMembers();
+  };
+
+  const handleDeleteMember = async (id: string) => {
+    await window.electronAPI.deleteMember(id);
+    setDeleteConfirm(null);
+    await loadMembers();
+  };
+
+  const startEdit = (member: Member) => {
+    setEditingMember(member);
+    setNewName(member.name);
+    setNewColor(member.color);
+    setShowAddForm(false);
+  };
+
+  const cancelEdit = () => {
+    setEditingMember(null);
+    setNewName('');
+    setNewColor(MEMBER_COLORS[0]);
+    setShowAddForm(false);
+  };
+
+  if (loading) {
+    return <div>加载中...</div>;
+  }
+
+  return (
+    <div className="members-page">
+      <div className="page-header">
+        <h2>家庭成员</h2>
+        <p className="page-subtitle">管理家庭成员，记录各自的支出</p>
+      </div>
+
+      <div className="members-toolbar">
+        <button className="btn-primary" onClick={() => { setShowAddForm(true); cancelEdit(); }}>
+          + 添加成员
+        </button>
+      </div>
+
+      {(showAddForm || editingMember) && (
+        <div className="member-form card">
+          <h3>{editingMember ? '编辑成员' : '添加新成员'}</h3>
+          <div className="form-group">
+            <label htmlFor="member-name">姓名</label>
+            <input
+              id="member-name"
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="请输入成员姓名"
+              autoFocus
+            />
+          </div>
+          <div className="form-group">
+            <label>颜色</label>
+            <div className="color-picker">
+              {MEMBER_COLORS.map((color) => (
+                <button
+                  key={color}
+                  className={`color-option ${newColor === color ? 'selected' : ''}`}
+                  style={{ backgroundColor: color }}
+                  onClick={() => setNewColor(color)}
+                  title={color}
+                />
+              ))}
+            </div>
+          </div>
+          <div className="form-actions">
+            <button className="btn-secondary" onClick={cancelEdit}>
+              取消
+            </button>
+            <button className="btn-primary" onClick={editingMember ? handleUpdateMember : handleAddMember}>
+              {editingMember ? '保存' : '添加'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {members.length === 0 && !showAddForm ? (
+        <div className="empty-state card">
+          <p>暂无家庭成员</p>
+          <p className="empty-hint">点击"添加成员"按钮来添加家庭成员</p>
+        </div>
+      ) : (
+        <div className="members-list">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>颜色</th>
+                <th>姓名</th>
+                <th>创建时间</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((member) => (
+                <tr key={member.id}>
+                  <td>
+                    <span
+                      className="member-color-badge"
+                      style={{ backgroundColor: member.color }}
+                    />
+                  </td>
+                  <td className="member-name">{member.name}</td>
+                  <td>{member.created_at.split('T')[0]}</td>
+                  <td className="actions">
+                    <button
+                      className="btn-secondary"
+                      onClick={() => startEdit(member)}
+                    >
+                      编辑
+                    </button>
+                    {deleteConfirm === member.id ? (
+                      <>
+                        <button
+                          className="btn-danger"
+                          onClick={() => handleDeleteMember(member.id)}
+                        >
+                          确认删除
+                        </button>
+                        <button
+                          className="btn-secondary"
+                          onClick={() => setDeleteConfirm(null)}
+                        >
+                          取消
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        className="btn-danger"
+                        onClick={() => setDeleteConfirm(member.id)}
+                      >
+                        删除
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="card">
+        <div className="card-header">
+          <h3 className="card-title">💡 使用说明</h3>
+        </div>
+        <ul className="help-list">
+          <li>添加家庭成员后，可以在交易记录中为每笔交易分配成员</li>
+          <li>仪表盘会显示各成员的支出占比</li>
+          <li>删除成员不会删除相关交易记录，仅解除关联</li>
+          <li>可以为每个成员选择不同的颜色以便区分</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/pages/Transactions.tsx
+++ b/src/renderer/pages/Transactions.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { CATEGORIES } from '../../shared/constants';
-import { DuplicateReviewItem, SortOrder, Transaction, TransactionQuery, TransactionSortBy } from '../../shared/types';
+import { DuplicateReviewItem, Member, SortOrder, Transaction, TransactionQuery, TransactionSortBy } from '../../shared/types';
 import { parseDrilldownQuery, removeDrilldownField, shouldApplyLatestResponse } from '../../shared/drilldown';
 
 interface FilterState {
@@ -10,6 +10,7 @@ interface FilterState {
   merchant: string;
   source: string;
   type: string;
+  memberId: string;
   q: string;
 }
 
@@ -31,6 +32,17 @@ const TYPE_LABELS: Record<string, string> = {
   income: '收入',
   transfer: '转账',
 };
+
+const MEMBER_COLORS = [
+  '#3B82F6', // blue
+  '#10B981', // green
+  '#EF4444', // red
+  '#8B5CF6', // purple
+  '#F59E0B', // orange
+  '#EC4899', // pink
+  '#14B8A6', // teal
+  '#6366F1', // indigo
+];
 
 // Helper functions to calculate date ranges
 function getStartOfWeek(date: Date): Date {
@@ -123,6 +135,7 @@ function isRefund(txn: Transaction): boolean {
 export default function Transactions({ locationSearch, onReplaceSearch }: TransactionsProps) {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [duplicates, setDuplicates] = useState<DuplicateReviewItem[]>([]);
+  const [members, setMembers] = useState<Member[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
@@ -133,6 +146,7 @@ export default function Transactions({ locationSearch, onReplaceSearch }: Transa
   const [tempNotes, setTempNotes] = useState('');
   const [editableTags, setEditableTags] = useState<string | null>(null);
   const [tempTags, setTempTags] = useState('');
+  const [editableMember, setEditableMember] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const tagsInputRef = useRef<HTMLInputElement>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -144,6 +158,7 @@ export default function Transactions({ locationSearch, onReplaceSearch }: Transa
     merchant: '',
     source: '',
     type: '',
+    memberId: '',
     q: '',
   });
   const drillQuery = useMemo(() => parseDrilldownQuery(locationSearch), [locationSearch]);
@@ -162,6 +177,7 @@ export default function Transactions({ locationSearch, onReplaceSearch }: Transa
         merchant: filter.merchant || undefined,
         source: (filter.source || undefined) as TransactionQuery['source'],
         type: (filter.type || undefined) as TransactionQuery['type'],
+        memberId: filter.memberId || undefined,
         q: filter.q || undefined,
         page,
         pageSize,
@@ -198,6 +214,18 @@ export default function Transactions({ locationSearch, onReplaceSearch }: Transa
 
   useEffect(() => {
     loadDuplicates();
+  }, []);
+
+  useEffect(() => {
+    const loadMembers = async () => {
+      try {
+        const data = await window.electronAPI.getMembers();
+        setMembers(data);
+      } catch (error) {
+        console.error('Failed to load members:', error);
+      }
+    };
+    loadMembers();
   }, []);
 
   useEffect(() => {
@@ -487,6 +515,15 @@ export default function Transactions({ locationSearch, onReplaceSearch }: Transa
           ))}
         </select>
 
+        <select value={filter.memberId} onChange={(e) => updateFilter({ memberId: e.target.value })}>
+          <option value="">所有成员</option>
+          {members.map((member) => (
+            <option key={member.id} value={member.id}>
+              {member.name}
+            </option>
+          ))}
+        </select>
+
         <select value={filter.source} onChange={(e) => updateFilter({ source: e.target.value })}>
           <option value="">所有来源</option>
           <option value="alipay">支付宝</option>
@@ -504,7 +541,7 @@ export default function Transactions({ locationSearch, onReplaceSearch }: Transa
         <button
           className="btn-secondary"
           onClick={() => {
-            setFilter({ startDate: '', endDate: '', category: '', merchant: '', source: '', type: '', q: '' });
+            setFilter({ startDate: '', endDate: '', category: '', merchant: '', source: '', type: '', memberId: '', q: '' });
             setPage(1);
             setSortBy('date');
             setSortOrder('desc');
@@ -608,6 +645,7 @@ export default function Transactions({ locationSearch, onReplaceSearch }: Transa
               <th>备注</th>
               <th>标签</th>
               <th>分类</th>
+              <th>成员</th>
               <th>来源</th>
               <th>退款关联</th>
               <th>去重</th>
@@ -617,7 +655,7 @@ export default function Transactions({ locationSearch, onReplaceSearch }: Transa
           <tbody>
             {transactions.length === 0 && (
               <tr>
-                <td colSpan={13}>暂无数据</td>
+                <td colSpan={14}>暂无数据</td>
               </tr>
             )}
             {transactions.map((txn) => {
@@ -701,6 +739,26 @@ export default function Transactions({ locationSearch, onReplaceSearch }: Transa
                       </option>
                     ))}
                   </select>
+                </td>
+                <td>
+                  {txn.member_id ? (
+                    (() => {
+                      const member = members.find(m => m.id === txn.member_id);
+                      return member ? (
+                        <span
+                          className="member-color-badge"
+                          style={{ backgroundColor: member.color }}
+                          title={member.name}
+                        >
+                          {member.name}
+                        </span>
+                      ) : (
+                        '-'
+                      );
+                    })()
+                  ) : (
+                    '-'
+                  )}
                 </td>
                 <td>{SOURCE_LABELS[txn.source] || txn.source}</td>
                 <td>{isRefund(txn) ? (txn.refund_of ? `原交易: ${txn.refund_of}` : '退款(未匹配)') : '-'}</td>

--- a/src/shared/drilldown.ts
+++ b/src/shared/drilldown.ts
@@ -6,14 +6,15 @@ export interface DrilldownQuery {
   drill?: boolean;
 }
 
-export type AppPage = 'dashboard' | 'budgets' | 'import' | 'transactions';
+export type AppPage = 'dashboard' | 'budgets' | 'members' | 'import' | 'transactions';
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 export function parseHashLocation(hash: string): { page: AppPage; search: string } {
   const raw = hash.startsWith('#') ? hash.slice(1) : hash;
   const [path, query = ''] = raw.split('?');
-  const page: AppPage = path === 'import' || path === 'transactions' ? path : 'dashboard';
+  const validPages: AppPage[] = ['dashboard', 'budgets', 'members', 'import', 'transactions'];
+  const page: AppPage = validPages.includes(path as AppPage) ? (path as AppPage) : 'dashboard';
   return { page, search: query ? `?${query}` : '' };
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,11 @@
+export interface Member {
+  id: string;
+  name: string;
+  color: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface Transaction {
   id: string;
   source: 'alipay' | 'wechat' | 'yunshanfu' | 'bank';
@@ -14,6 +22,7 @@ export interface Transaction {
   category?: string;
   notes?: string;
   tags?: string;
+  member_id?: string | null;
   is_refund?: boolean | number;
   refund_of?: string | null;
   is_duplicate?: boolean | number;
@@ -64,6 +73,13 @@ export interface SummaryMerchantItem {
   total: number;
 }
 
+export interface MemberSummaryItem {
+  memberId: string;
+  memberName: string;
+  memberColor: string;
+  total: number;
+}
+
 export interface Summary {
   year: number;
   currentMonth: string;
@@ -75,6 +91,7 @@ export interface Summary {
   monthly: SummaryMonthlyItem[];
   byCategory: SummaryCategoryItem[];
   topMerchants: SummaryMerchantItem[];
+  byMember?: MemberSummaryItem[];
   availableYears: number[];
 }
 
@@ -93,6 +110,7 @@ export interface TransactionQuery {
   endDate?: string;
   duplicateType?: DuplicateType;
   refundOnly?: boolean;
+  memberId?: string;
   q?: string;
   page?: number;
   pageSize?: number;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -141,3 +141,52 @@ export interface BudgetAlert {
   percentage: number;
   status: 'ok' | 'warning' | 'exceeded';
 }
+
+// Smart Assignment Types
+export type FeatureKey = 'counterparty' | 'category' | 'description' | 'merchant_keyword';
+
+export interface AssignmentHistory {
+  id: string;
+  transaction_id: string;
+  member_id: string;
+  feature_key: FeatureKey;
+  feature_value: string;
+  created_at: string;
+}
+
+export interface AssignmentPattern {
+  id: string;
+  feature_key: FeatureKey;
+  feature_value: string;
+  member_id: string;
+  count: number;
+  confidence: number;
+  updated_at: string;
+}
+
+export interface PredictionResult {
+  transactionId: string;
+  memberId: string | null;
+  memberName: string | null;
+  confidence: number;
+  action: 'auto_assign' | 'suggest' | 'none';
+  matchedFeatures: Array<{
+    featureKey: FeatureKey;
+    featureValue: string;
+  }>;
+}
+
+export interface LearnAssignmentParams {
+  transactionId: string;
+  memberId: string;
+  counterparty?: string;
+  category?: string;
+  description?: string;
+}
+
+export interface ApplySmartAssignmentResult {
+  processed: number;
+  autoAssigned: number;
+  suggested: number;
+  results: PredictionResult[];
+}


### PR DESCRIPTION
## 功能说明

实现智能账单分摊功能，通过学习用户的历史分配模式自动预测新账单的成员归属。

### 核心逻辑

**学习阶段：**
- 用户手动分配交易时，系统记录特征（商户、分类、描述关键词）
- 统计每个特征组合对应的成员频次，计算置信度

**预测阶段：**
- 导入新账单时，根据学到的模式预测成员
- 置信度 >= 70%：自动分配
- 置信度 30%-70%：建议但不自动
- 置信度 < 30%：不处理

### 新增功能
-  - 学习手动分配
-  - 预测单笔交易成员
-  - 批量预测自动分配
-  - 查看学习到的模式
-  - 删除模式

### 测试
- npm test: 98/98 通过
- npm run build: 成功