### PR TITLE
feat: 邮件自动捕获

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "cheerio": "^1.2.0",
         "chokidar": "^4.0.0",
         "commander": "^5.1.0",
+        "imap": "^0.8.19",
+        "mailparser": "^3.9.3",
         "papaparse": "^5.4.1",
         "pdf-parse": "^1.1.4",
         "react": "^18.3.1",
@@ -24,6 +26,8 @@
         "expense-cli": "dist/cli.js"
       },
       "devDependencies": {
+        "@types/imap": "^0.8.43",
+        "@types/mailparser": "^3.4.6",
         "@types/papaparse": "^5.3.15",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
@@ -3005,6 +3009,19 @@
         "win32"
       ]
     },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "dev": true,
@@ -3167,12 +3184,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/imap": {
+      "version": "0.8.43",
+      "resolved": "https://registry.npmjs.org/@types/imap/-/imap-0.8.43.tgz",
+      "integrity": "sha512-POPoqrDax9mxM2N4ITZYCWaFtg1ORVfzJe4S7xwSh9aHawdEb7FwWTJYiAhzIvWp7DM+6BajnzYOwZ1BUrqtow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mailparser": {
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@types/mailparser/-/mailparser-3.4.6.tgz",
+      "integrity": "sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "iconv-lite": "^0.6.3"
       }
     },
     "node_modules/@types/ms": {
@@ -3290,6 +3328,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@zone-eu/mailsplit": {
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
+      "integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1"
       }
     },
     "node_modules/7zip-bin": {
@@ -4499,7 +4548,6 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/crc": {
@@ -4806,7 +4854,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5304,6 +5351,15 @@
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/encoding-sniffer": {
@@ -6164,6 +6220,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "dev": true,
@@ -6190,6 +6255,41 @@
       "version": "4.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/html-to-text/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -6323,6 +6423,42 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/imap": {
+      "version": "0.8.19",
+      "resolved": "https://registry.npmjs.org/imap/-/imap-0.8.19.tgz",
+      "integrity": "sha512-z5DxEA1uRnZG73UcPA4ES5NSCGnPuuouUx43OPX7KZx1yzq3N8/vx2mtXEShT5inxB3pRgnfG1hijfu7XN2YMw==",
+      "dependencies": {
+        "readable-stream": "1.1.x",
+        "utf7": ">=1.0.2"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/imap/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
+    "node_modules/imap/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/imap/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "license": "MIT"
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
@@ -6355,7 +6491,6 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -7023,6 +7158,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7031,6 +7175,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/libbase64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+      "license": "MIT"
+    },
+    "node_modules/libmime": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
+      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.6.3",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/libqp": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
+      "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/lodash": {
@@ -7130,6 +7307,40 @@
       "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/mailparser": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.3.tgz",
+      "integrity": "sha512-AnB0a3zROum6fLaa52L+/K2SoRJVyFDk78Ea6q1D0ofcZLxWEWDtsS1+OrVqKbV7r5dulKL/AwYQccFGAPpuYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zone-eu/mailsplit": "5.4.8",
+        "encoding-japanese": "2.2.0",
+        "he": "1.2.0",
+        "html-to-text": "9.0.5",
+        "iconv-lite": "0.7.2",
+        "libmime": "5.3.7",
+        "linkify-it": "5.0.0",
+        "nodemailer": "7.0.13",
+        "punycode.js": "2.3.1",
+        "tlds": "1.261.0"
+      }
+    },
+    "node_modules/mailparser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -7533,6 +7744,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nodemailer": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "6.0.0",
       "dev": true,
@@ -7795,6 +8015,19 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "dev": true,
@@ -7871,6 +8104,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/pend": {
@@ -8013,6 +8255,15 @@
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8590,6 +8841,18 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/semver": {
@@ -9366,6 +9629,15 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tlds": {
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+      "license": "MIT",
+      "bin": {
+        "tlds": "bin.js"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "dev": true,
@@ -9508,6 +9780,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -9673,6 +9951,23 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utf7": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utf7/-/utf7-1.0.2.tgz",
+      "integrity": "sha512-qQrPtYLLLl12NF4DrM9CvfkxkYI97xOb5dsnGZHE3teFr0tWiEZ9UdgMPczv24vl708cYMpe6mGXGHrotIp3Bw==",
+      "dependencies": {
+        "semver": "~5.3.0"
+      }
+    },
+    "node_modules/utf7/node_modules/semver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha512-mfmm3/H9+67MCVix1h+IXTpDwL6710LyHuk7+cWC9T1mE0qz4iHhh6r4hU2wrIT9iTsAAC2XQRvfblL028cpLw==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/utf8-byte-length": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "cheerio": "^1.2.0",
     "chokidar": "^4.0.0",
     "commander": "^5.1.0",
+    "imap": "^0.8.19",
+    "mailparser": "^3.9.3",
     "papaparse": "^5.4.1",
     "pdf-parse": "^1.1.4",
     "react": "^18.3.1",
@@ -31,6 +33,8 @@
     "tesseract.js": "^5.1.1"
   },
   "devDependencies": {
+    "@types/imap": "^0.8.43",
+    "@types/mailparser": "^3.4.6",
     "@types/papaparse": "^5.3.15",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -2,7 +2,7 @@ import initSqlJs from 'sql.js';
 import path from 'path';
 import fs from 'fs';
 import { app } from 'electron';
-import { Budget, Member, Transaction, AssignmentHistory, AssignmentPattern, SmartAssignmentResult } from '../shared/types';
+import { Budget, Member, Transaction, AssignmentHistory, AssignmentPattern, SmartAssignmentResult, EmailAccount, EmailMessage } from '../shared/types';
 import { TRIAGE_RULES, matchTriageRule } from '../shared/constants';
 
 let db: any = null;
@@ -153,6 +153,42 @@ function ensureSchema(): void {
 
   database.run('CREATE INDEX IF NOT EXISTS idx_assignment_history_transaction ON assignment_history(transaction_id)');
   database.run('CREATE INDEX IF NOT EXISTS idx_assignment_patterns_key_value ON assignment_patterns(feature_key, feature_value)');
+
+  // Email accounts table
+  database.run(`
+    CREATE TABLE IF NOT EXISTS email_accounts (
+      id TEXT PRIMARY KEY,
+      email TEXT NOT NULL,
+      imap_host TEXT NOT NULL,
+      imap_port INTEGER DEFAULT 993,
+      smtp_host TEXT,
+      smtp_port INTEGER DEFAULT 465,
+      username TEXT NOT NULL,
+      password TEXT NOT NULL,
+      last_sync TEXT,
+      created_at TEXT NOT NULL
+    )
+  `);
+
+  // Email messages table
+  database.run(`
+    CREATE TABLE IF NOT EXISTS email_messages (
+      id TEXT PRIMARY KEY,
+      account_id TEXT NOT NULL,
+      message_id TEXT NOT NULL,
+      subject TEXT,
+      from_address TEXT,
+      date TEXT,
+      attachments TEXT,
+      processed INTEGER DEFAULT 0,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (account_id) REFERENCES email_accounts(id) ON DELETE CASCADE
+    )
+  `);
+
+  database.run('CREATE INDEX IF NOT EXISTS idx_email_messages_account ON email_messages(account_id)');
+  database.run('CREATE INDEX IF NOT EXISTS idx_email_messages_message_id ON email_messages(message_id)');
+  database.run('CREATE INDEX IF NOT EXISTS idx_email_messages_processed ON email_messages(processed)');
 
   const now = new Date().toISOString();
   database.run(
@@ -1144,4 +1180,137 @@ export function batchAssignSimilar(
   }
 
   return toUpdate.length;
+}
+
+// ============== Email Account Functions ==============
+
+export function getEmailAccounts(): EmailAccount[] {
+  const database = getDatabase();
+  const stmt = database.prepare('SELECT * FROM email_accounts ORDER BY created_at DESC');
+  const results: EmailAccount[] = [];
+  while (stmt.step()) {
+    const row = stmt.getAsObject() as unknown as EmailAccount;
+    // Don't expose password in plain text
+    results.push({
+      ...row,
+      password: '********',
+    });
+  }
+  stmt.free();
+  return results;
+}
+
+export function addEmailAccount(
+  id: string,
+  email: string,
+  imapHost: string,
+  imapPort: number,
+  smtpHost: string,
+  smtpPort: number,
+  username: string,
+  password: string
+): void {
+  const database = getDatabase();
+  const now = new Date().toISOString();
+  database.run(
+    `INSERT INTO email_accounts (id, email, imap_host, imap_port, smtp_host, smtp_port, username, password, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [id, email, imapHost, imapPort, smtpHost, smtpPort, username, password, now]
+  );
+  saveDatabase();
+}
+
+export function deleteEmailAccount(id: string): void {
+  const database = getDatabase();
+  // Delete associated email messages first
+  database.run('DELETE FROM email_messages WHERE account_id = ?', [id]);
+  database.run('DELETE FROM email_accounts WHERE id = ?', [id]);
+  saveDatabase();
+}
+
+export function updateEmailAccountLastSync(id: string): void {
+  const database = getDatabase();
+  const now = new Date().toISOString();
+  database.run('UPDATE email_accounts SET last_sync = ? WHERE id = ?', [now, id]);
+  saveDatabase();
+}
+
+export function getEmailAccountById(id: string): EmailAccount | null {
+  const database = getDatabase();
+  const stmt = database.prepare('SELECT * FROM email_accounts WHERE id = ?');
+  stmt.bind([id]);
+  let account: EmailAccount | null = null;
+  if (stmt.step()) {
+    account = stmt.getAsObject() as unknown as EmailAccount;
+  }
+  stmt.free();
+  return account;
+}
+
+export function getEmailAccountPassword(id: string): string | null {
+  const database = getDatabase();
+  const stmt = database.prepare('SELECT password FROM email_accounts WHERE id = ?');
+  stmt.bind([id]);
+  let password: string | null = null;
+  if (stmt.step()) {
+    const row = stmt.getAsObject() as { password: string };
+    password = row.password;
+  }
+  stmt.free();
+  return password;
+}
+
+// ============== Email Message Functions ==============
+
+export function saveEmailMessage(
+  id: string,
+  accountId: string,
+  messageId: string,
+  subject: string | null,
+  fromAddress: string | null,
+  date: string | null,
+  attachments: string | null
+): void {
+  const database = getDatabase();
+  const now = new Date().toISOString();
+  database.run(
+    `INSERT OR REPLACE INTO email_messages (id, account_id, message_id, subject, from_address, date, attachments, processed, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)`,
+    [id, accountId, messageId, subject, fromAddress, date, attachments, now]
+  );
+  saveDatabase();
+}
+
+export function getUnprocessedEmails(accountId: string): EmailMessage[] {
+  const database = getDatabase();
+  const stmt = database.prepare(
+    'SELECT * FROM email_messages WHERE account_id = ? AND processed = 0 ORDER BY date DESC'
+  );
+  stmt.bind([accountId]);
+  const results: EmailMessage[] = [];
+  while (stmt.step()) {
+    results.push(stmt.getAsObject() as unknown as EmailMessage);
+  }
+  stmt.free();
+  return results;
+}
+
+export function markEmailAsProcessed(id: string): void {
+  const database = getDatabase();
+  database.run('UPDATE email_messages SET processed = 1 WHERE id = ?', [id]);
+  saveDatabase();
+}
+
+export function getEmailMessages(accountId: string, limit = 50): EmailMessage[] {
+  const database = getDatabase();
+  const stmt = database.prepare(
+    'SELECT * FROM email_messages WHERE account_id = ? ORDER BY date DESC LIMIT ?'
+  );
+  stmt.bind([accountId, limit]);
+  const results: EmailMessage[] = [];
+  while (stmt.step()) {
+    results.push(stmt.getAsObject() as unknown as EmailMessage);
+  }
+  stmt.free();
+  return results;
 }

--- a/src/main/email.ts
+++ b/src/main/email.ts
@@ -1,0 +1,285 @@
+import { getEmailAccounts, getEmailAccountPassword, updateEmailAccountLastSync } from './database';
+import { saveEmailMessage as dbSaveEmailMessage } from './database';
+import * as fs from 'fs';
+import * as path from 'path';
+import { app } from 'electron';
+import Imap from 'imap';
+import { simpleParser } from 'mailparser';
+
+// Keywords to search for billing/invoice emails
+const BILLING_KEYWORDS = [
+  '账单',
+  '发票',
+  '消费',
+  'bill',
+  'invoice',
+  'payment',
+  '账单明细',
+  '电子发票',
+  '消费记录',
+];
+
+// Keywords to search in email subjects
+const BILLING_SUBJECT_KEYWORDS = [
+  '账单',
+  '发票',
+  'bill',
+  'invoice',
+  '消费',
+  'payment',
+];
+
+export interface EmailSyncOptions {
+  accountId: string;
+  since?: Date;
+  keywords?: string[];
+  downloadDir?: string;
+}
+
+/**
+ * Connect to IMAP server and fetch emails
+ */
+export async function connectToEmail(account: any): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const imap = new Imap({
+      user: account.username,
+      password: account.password,
+      host: account.imap_host,
+      port: account.imap_port,
+      tls: true,
+      connTimeout: 30000,
+    });
+
+    imap.once('ready', () => {
+      resolve(imap);
+    });
+
+    imap.once('error', (err: Error) => {
+      reject(err);
+    });
+
+    imap.connect();
+  });
+}
+
+/**
+ * Search and fetch emails matching billing keywords
+ */
+export async function searchBillingEmails(
+  imap: any,
+  keywords: string[] = BILLING_SUBJECT_KEYWORDS
+): Promise<any[]> {
+  return new Promise((resolve, reject) => {
+    const searchCriteria = [
+      'ALL',
+      ['SUBJECT', keywords.join(' OR ')],
+    ];
+
+    imap.search(searchCriteria, (err: Error, results: number[]) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      if (results.length === 0) {
+        resolve([]);
+        return;
+      }
+
+      const fetch = imap.fetch(results, {
+        bodies: '',
+        struct: true,
+      });
+
+      const emails: any[] = [];
+
+      fetch.on('message', (msg: any) => {
+        let emailData: any = {
+          headers: null,
+          body: null,
+        };
+
+        msg.on('body', (stream: any) => {
+          simpleParser(stream, (err: Error, parsed: any) => {
+            if (!err) {
+              emailData.body = parsed;
+            }
+          });
+        });
+
+        msg.once('attributes', (attrs: any) => {
+          emailData.headers = attrs;
+        });
+
+        msg.once('end', () => {
+          emails.push(emailData);
+        });
+      });
+
+      fetch.once('error', (err: Error) => {
+        reject(err);
+      });
+
+      fetch.once('end', () => {
+        resolve(emails);
+      });
+    });
+  });
+}
+
+/**
+ * Download email attachments
+ */
+export async function downloadAttachments(
+  imap: any,
+  message: any,
+  downloadDir: string
+): Promise<Array<{ filename: string; path: string }>> {
+  const attachments: Array<{ filename: string; path: string }> = [];
+
+  if (!message.body) return attachments;
+
+  try {
+    // Process parts
+    if (message.body && message.body.attachments) {
+      for (const attachment of message.body.attachments) {
+        if (attachment.contentType === 'application/pdf' || 
+            attachment.contentType.startsWith('image/')) {
+          const filename = attachment.filename || `attachment_${Date.now()}.pdf`;
+          const filepath = path.join(downloadDir, filename);
+          
+          if (attachment.content && attachment.content.length > 0) {
+            fs.writeFileSync(filepath, attachment.content);
+            attachments.push({ filename, path: filepath });
+          }
+        }
+      }
+    }
+  } catch (err) {
+    console.error('Error downloading attachments:', err);
+  }
+
+  return attachments;
+}
+
+/**
+ * Sync emails for a specific account
+ */
+export async function syncEmailAccount(options: EmailSyncOptions): Promise<{
+  success: boolean;
+  emailsFound: number;
+  attachmentsDownloaded: number;
+  errors: string[];
+}> {
+  const { accountId, downloadDir } = options;
+  const errors: string[] = [];
+  let emailsFound = 0;
+  let attachmentsDownloaded = 0;
+
+  try {
+    // Get account info from database
+    const accounts = getEmailAccounts();
+    const account = accounts.find(a => a.id === accountId);
+    
+    if (!account) {
+      return {
+        success: false,
+        emailsFound: 0,
+        attachmentsDownloaded: 0,
+        errors: ['Account not found'],
+      };
+    }
+
+    // Get real password (not the masked one)
+    const password = getEmailAccountPassword(accountId);
+    if (!password) {
+      return {
+        success: false,
+        emailsFound: 0,
+        attachmentsDownloaded: 0,
+        errors: ['Account password not found'],
+      };
+    }
+
+    // Create temp directory for downloads
+    const tempDir = downloadDir || path.join(app.getPath('userData'), 'email_downloads');
+    if (!fs.existsSync(tempDir)) {
+      fs.mkdirSync(tempDir, { recursive: true });
+    }
+
+    // Connect to IMAP
+    const imap = await connectToEmail({
+      ...account,
+      password,
+    });
+
+    // Search for billing emails
+    const emails = await searchBillingEmails(imap);
+
+    for (const emailData of emails) {
+      if (!emailData.body) continue;
+
+      emailsFound++;
+
+      // Save email to database
+      const messageId = emailData.headers?.['message-id'] || `msg_${Date.now()}_${Math.random()}`;
+      const subject = emailData.body.subject || '';
+      const from = emailData.body.from?.value?.[0]?.address || '';
+
+      // Process attachments
+      if (emailData.body.attachments) {
+        for (const attachment of emailData.body.attachments) {
+          // Only download PDFs and images
+          if (attachment.contentType === 'application/pdf' || 
+              attachment.contentType.startsWith('image/')) {
+            try {
+              const filename = attachment.filename || `attachment_${Date.now()}.pdf`;
+              const filepath = path.join(tempDir, filename);
+              
+              if (attachment.content && attachment.content.length > 0) {
+                fs.writeFileSync(filepath, attachment.content);
+                attachmentsDownloaded++;
+              }
+            } catch (err: any) {
+              errors.push(`Failed to download attachment: ${err.message}`);
+            }
+          }
+        }
+      }
+
+      // Save email record
+      try {
+        dbSaveEmailMessage(
+          `msg_${Date.now()}_${Math.random()}`,
+          accountId,
+          messageId,
+          subject,
+          from,
+          null,
+          JSON.stringify(emailData.body.attachments || []),
+        );
+      } catch (err: any) {
+        errors.push(`Failed to save email: ${err.message}`);
+      }
+    }
+
+    imap.end();
+
+    // Update last sync time
+    updateEmailAccountLastSync(accountId);
+
+    return {
+      success: true,
+      emailsFound,
+      attachmentsDownloaded,
+      errors,
+    };
+  } catch (err: any) {
+    return {
+      success: false,
+      emailsFound: 0,
+      attachmentsDownloaded: 0,
+      errors: [err.message],
+    };
+  }
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -5,7 +5,7 @@ import { execFileSync } from 'child_process';
 import { TextDecoder } from 'util';
 import Papa from 'papaparse';
 import { Dialog, IpcMain } from 'electron';
-import { getDatabase, getDatabasePath, deleteBudget, getBudgets, getBudgetSpending, insertTransactions, saveDatabase, setBudget, getTransactionTags, addTransactionTag, removeTransactionTag, updateTransactionCurrency, getMembers, addMember, updateMember, deleteMember, setTransactionMember, getMemberSpendingSummary, learnAssignment, predictMember, getPatterns, deletePattern, applyTriageRules, autoApplyTriageRules, checkSimilarAssignments, batchAssignSimilar } from './database';
+import { getDatabase, getDatabasePath, deleteBudget, getBudgets, getBudgetSpending, insertTransactions, saveDatabase, setBudget, getTransactionTags, addTransactionTag, removeTransactionTag, updateTransactionCurrency, getMembers, addMember, updateMember, deleteMember, setTransactionMember, getMemberSpendingSummary, learnAssignment, predictMember, getPatterns, deletePattern, applyTriageRules, autoApplyTriageRules, checkSimilarAssignments, batchAssignSimilar, getEmailAccounts, addEmailAccount, deleteEmailAccount, getEmailMessages } from './database';
 import { parseAlipay } from '../parsers/alipay';
 import { parseBank } from '../parsers/bank';
 import { parseWechat } from '../parsers/wechat';
@@ -13,7 +13,7 @@ import { parseYunshanfu } from '../parsers/yunshanfu';
 import { parsePdfBill } from '../parsers/pdf';
 import { parseHtmlBill } from '../parsers/html';
 import { parseImageBillWithOcr } from '../parsers/ocr';
-import { Budget, BudgetAlert, DuplicateReviewItem, DuplicateType, Member, Summary, SummaryQuery, Transaction, TransactionListResponse, TransactionQuery, TransactionSource, SmartAssignmentResult, SmartAssignmentApplyResult } from '../shared/types';
+import { Budget, BudgetAlert, DuplicateReviewItem, DuplicateType, Member, Summary, SummaryQuery, Transaction, TransactionListResponse, TransactionQuery, TransactionSource, SmartAssignmentResult, SmartAssignmentApplyResult, EmailAccount, EmailMessage } from '../shared/types';
 import { buildTransactionWhereClause } from './ipcFilters';
 
 type Source = TransactionSource;
@@ -1310,5 +1310,38 @@ export function setupIpcHandlers(ipcMain: IpcMain, dialog: Dialog): void {
 
   ipcMain.handle('batch-assign-similar', async (_, transaction: Transaction, memberId: string) => {
     return batchAssignSimilar(transaction, memberId);
+  });
+
+  // Email account handlers
+  ipcMain.handle('get-email-accounts', async (): Promise<EmailAccount[]> => {
+    return getEmailAccounts();
+  });
+
+  ipcMain.handle('add-email-account', async (
+    _,
+    id: string,
+    email: string,
+    imapHost: string,
+    imapPort: number,
+    smtpHost: string,
+    smtpPort: number,
+    username: string,
+    password: string
+  ): Promise<void> => {
+    addEmailAccount(id, email, imapHost, imapPort, smtpHost, smtpPort, username, password);
+  });
+
+  ipcMain.handle('delete-email-account', async (_, id: string): Promise<void> => {
+    deleteEmailAccount(id);
+  });
+
+  ipcMain.handle('get-email-messages', async (_, accountId: string, limit?: number): Promise<EmailMessage[]> => {
+    return getEmailMessages(accountId, limit ?? 50);
+  });
+
+  ipcMain.handle('sync-emails', async (_, accountId: string) => {
+    // Dynamic import to avoid issues
+    const { syncEmailAccount } = await import('./email');
+    return syncEmailAccount({ accountId });
   });
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Budget, BudgetAlert, DuplicateReviewItem, Member, Summary, SummaryQuery, Transaction, TransactionListResponse, TransactionQuery } from '../shared/types';
+import { Budget, BudgetAlert, DuplicateReviewItem, Member, Summary, SummaryQuery, Transaction, TransactionListResponse, TransactionQuery, EmailAccount, EmailMessage } from '../shared/types';
 import { AppPage, buildDrilldownQuery, parseHashLocation } from '../shared/drilldown';
 import Dashboard from './pages/Dashboard';
 import Import from './pages/Import';
@@ -7,6 +7,7 @@ import Transactions from './pages/Transactions';
 import Budgets from './pages/Budgets';
 import Members from './pages/Members';
 import AssignTransactions from './pages/AssignTransactions';
+import EmailSettings from './pages/EmailSettings';
 
 declare global {
   interface Window {
@@ -74,6 +75,25 @@ declare global {
         }>;
       }>;
       batchAssignSimilar: (transaction: Transaction, memberId: string) => Promise<number>;
+      getEmailAccounts: () => Promise<EmailAccount[]>;
+      addEmailAccount: (
+        id: string,
+        email: string,
+        imapHost: string,
+        imapPort: number,
+        smtpHost: string,
+        smtpPort: number,
+        username: string,
+        password: string
+      ) => Promise<void>;
+      deleteEmailAccount: (id: string) => Promise<void>;
+      getEmailMessages: (accountId: string, limit?: number) => Promise<EmailMessage[]>;
+      syncEmails: (accountId: string) => Promise<{
+        success: boolean;
+        emailsFound: number;
+        attachmentsDownloaded: number;
+        errors: string[];
+      }>;
     };
   }
 }
@@ -85,6 +105,7 @@ const navItems = [
   { page: 'assign', label: '分配交易', icon: '📤' },
   { page: 'import', label: '导入', icon: '📥' },
   { page: 'transactions', label: '交易记录', icon: '📋' },
+  { page: 'email-settings', label: '邮箱设置', icon: '📧' },
 ] as const;
 
 export default function App() {
@@ -147,6 +168,7 @@ export default function App() {
           />
         )}
         {currentPage === 'assign' && <AssignTransactions />}
+        {currentPage === 'email-settings' && <EmailSettings />}
       </main>
     </div>
   );

--- a/src/renderer/pages/EmailSettings.tsx
+++ b/src/renderer/pages/EmailSettings.tsx
@@ -1,0 +1,462 @@
+import { useEffect, useState } from 'react';
+import { EmailAccount, EmailMessage } from '../../shared/types';
+
+// Common email providers with IMAP settings
+const EMAIL_PROVIDERS = {
+  '163': {
+    email: '@163.com',
+    imap_host: 'imap.163.com',
+    imap_port: 993,
+    smtp_host: 'smtp.163.com',
+    smtp_port: 465,
+  },
+  'qq': {
+    email: '@qq.com',
+    imap_host: 'imap.qq.com',
+    imap_port: 993,
+    smtp_host: 'smtp.qq.com',
+    smtp_port: 465,
+  },
+  '126': {
+    email: '@126.com',
+    imap_host: 'imap.126.com',
+    imap_port: 993,
+    smtp_host: 'smtp.126.com',
+    smtp_port: 465,
+  },
+  'gmail': {
+    email: '@gmail.com',
+    imap_host: 'imap.gmail.com',
+    imap_port: 993,
+    smtp_host: 'smtp.gmail.com',
+    smtp_port: 465,
+  },
+  'outlook': {
+    email: '@outlook.com',
+    imap_host: 'imap.outlook.com',
+    imap_port: 993,
+    smtp_host: 'smtp.outlook.com',
+    smtp_port: 587,
+  },
+  'custom': {
+    email: '',
+    imap_host: '',
+    imap_port: 993,
+    smtp_host: '',
+    smtp_port: 465,
+  },
+};
+
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2);
+}
+
+export default function EmailSettings() {
+  const [accounts, setAccounts] = useState<EmailAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [syncing, setSyncing] = useState<string | null>(null);
+  const [message, setMessage] = useState('');
+  
+  // Form state
+  const [email, setEmail] = useState('');
+  const [provider, setProvider] = useState('163');
+  const [imapHost, setImapHost] = useState('imap.163.com');
+  const [imapPort, setImapPort] = useState(993);
+  const [smtpHost, setSmtpHost] = useState('smtp.163.com');
+  const [smtpPort, setSmtpPort] = useState(465);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+  
+  // View state
+  const [selectedAccount, setSelectedAccount] = useState<EmailAccount | null>(null);
+  const [messages, setMessages] = useState<EmailMessage[]>([]);
+  const [loadingMessages, setLoadingMessages] = useState(false);
+
+  useEffect(() => {
+    loadAccounts();
+  }, []);
+
+  const loadAccounts = async () => {
+    try {
+      const data = await window.electronAPI.getEmailAccounts();
+      setAccounts(data);
+    } catch (error) {
+      console.error('Failed to load email accounts:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleProviderChange = (newProvider: string) => {
+    setProvider(newProvider);
+    if (newProvider !== 'custom' && EMAIL_PROVIDERS[newProvider as keyof typeof EMAIL_PROVIDERS]) {
+      const p = EMAIL_PROVIDERS[newProvider as keyof typeof EMAIL_PROVIDERS];
+      setImapHost(p.imap_host);
+      setImapPort(p.imap_port);
+      setSmtpHost(p.smtp_host);
+      setSmtpPort(p.smtp_port);
+      
+      // Auto-fill username if email is set
+      if (email) {
+        const emailPrefix = email.split('@')[0];
+        setUsername(emailPrefix);
+      }
+    }
+  };
+
+  const handleEmailChange = (newEmail: string) => {
+    setEmail(newEmail);
+    
+    // Auto-detect provider from email
+    if (newEmail.includes('@163.com')) {
+      handleProviderChange('163');
+    } else if (newEmail.includes('@qq.com')) {
+      handleProviderChange('qq');
+    } else if (newEmail.includes('@126.com')) {
+      handleProviderChange('126');
+    } else if (newEmail.includes('@gmail.com')) {
+      handleProviderChange('gmail');
+    } else if (newEmail.includes('@outlook.com')) {
+      handleProviderChange('outlook');
+    } else if (newEmail.includes('@')) {
+      handleProviderChange('custom');
+    }
+    
+    // Update username
+    const emailPrefix = newEmail.split('@')[0];
+    if (emailPrefix) {
+      setUsername(emailPrefix);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!email || !username || !password) {
+      setMessage('请填写完整的邮箱信息');
+      return;
+    }
+
+    setSaving(true);
+    setMessage('');
+
+    try {
+      const id = generateId();
+      await window.electronAPI.addEmailAccount(
+        id,
+        email,
+        imapHost,
+        imapPort,
+        smtpHost,
+        smtpPort,
+        username,
+        password
+      );
+      
+      // Reload accounts
+      await loadAccounts();
+      
+      // Reset form
+      setShowAddForm(false);
+      setEmail('');
+      setPassword('');
+      setMessage('邮箱账户添加成功！');
+    } catch (error) {
+      setMessage(`添加失败: ${String(error)}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('确定要删除这个邮箱账户吗？')) return;
+    
+    try {
+      await window.electronAPI.deleteEmailAccount(id);
+      await loadAccounts();
+      if (selectedAccount?.id === id) {
+        setSelectedAccount(null);
+        setMessages([]);
+      }
+      setMessage('邮箱账户已删除');
+    } catch (error) {
+      setMessage(`删除失败: ${String(error)}`);
+    }
+  };
+
+  const handleSync = async (accountId: string) => {
+    setSyncing(accountId);
+    setMessage('');
+
+    try {
+      const result = await window.electronAPI.syncEmails(accountId);
+      
+      if (result.success) {
+        setMessage(`同步完成：找到 ${result.emailsFound} 封邮件，下载 ${result.attachmentsDownloaded} 个附件`);
+      } else {
+        setMessage(`同步失败: ${result.errors.join(', ')}`);
+      }
+      
+      // Reload messages if selected
+      if (selectedAccount?.id === accountId) {
+        loadMessages(accountId);
+      }
+    } catch (error) {
+      setMessage(`同步失败: ${String(error)}`);
+    } finally {
+      setSyncing(null);
+    }
+  };
+
+  const handleSelectAccount = async (account: EmailAccount) => {
+    setSelectedAccount(account);
+    await loadMessages(account.id);
+  };
+
+  const loadMessages = async (accountId: string) => {
+    setLoadingMessages(true);
+    try {
+      const data = await window.electronAPI.getEmailMessages(accountId);
+      setMessages(data);
+    } catch (error) {
+      console.error('Failed to load email messages:', error);
+    } finally {
+      setLoadingMessages(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="page">加载中...</div>;
+  }
+
+  return (
+    <div className="page email-settings">
+      <div className="page-header">
+        <h1>📧 邮箱设置</h1>
+        <p className="subtitle">管理邮箱账户，自动同步账单和发票邮件</p>
+      </div>
+
+      {message && (
+        <div className={`message ${message.includes('失败') || message.includes('错误') ? 'error' : 'success'}`}>
+          {message}
+        </div>
+      )}
+
+      {/* Account List */}
+      <div className="section">
+        <div className="section-header">
+          <h2>已配置的邮箱账户</h2>
+          <button 
+            className="btn btn-primary"
+            onClick={() => setShowAddForm(!showAddForm)}
+          >
+            {showAddForm ? '取消' : '+ 添加账户'}
+          </button>
+        </div>
+
+        {accounts.length === 0 && !showAddForm ? (
+          <div className="empty-state">
+            <p>还没有配置邮箱账户</p>
+            <p className="hint">点击上方按钮添加邮箱账户，自动同步账单和发票</p>
+          </div>
+        ) : (
+          <div className="account-list">
+            {accounts.map(account => (
+              <div 
+                key={account.id} 
+                className={`account-card ${selectedAccount?.id === account.id ? 'selected' : ''}`}
+                onClick={() => handleSelectAccount(account)}
+              >
+                <div className="account-info">
+                  <div className="account-email">{account.email}</div>
+                  <div className="account-meta">
+                    <span>IMAP: {account.imap_host}:{account.imap_port}</span>
+                    {account.last_sync && (
+                      <span>上次同步: {new Date(account.last_sync).toLocaleString()}</span>
+                    )}
+                  </div>
+                </div>
+                <div className="account-actions">
+                  <button
+                    className="btn btn-small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleSync(account.id);
+                    }}
+                    disabled={syncing === account.id}
+                  >
+                    {syncing === account.id ? '同步中...' : '🔄 同步'}
+                  </button>
+                  <button
+                    className="btn btn-small btn-danger"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDelete(account.id);
+                    }}
+                  >
+                    删除
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Add Account Form */}
+      {showAddForm && (
+        <div className="section">
+          <h2>添加邮箱账户</h2>
+          <form onSubmit={handleSubmit} className="form">
+            <div className="form-group">
+              <label>邮箱地址</label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => handleEmailChange(e.target.value)}
+                placeholder="yourname@163.com"
+                required
+              />
+            </div>
+
+            <div className="form-group">
+              <label>邮箱提供商</label>
+              <select value={provider} onChange={(e) => handleProviderChange(e.target.value)}>
+                <option value="163">163 邮箱</option>
+                <option value="qq">QQ 邮箱</option>
+                <option value="126">126 邮箱</option>
+                <option value="gmail">Gmail</option>
+                <option value="outlook">Outlook</option>
+                <option value="custom">自定义</option>
+              </select>
+            </div>
+
+            <div className="form-row">
+              <div className="form-group">
+                <label>IMAP 服务器</label>
+                <input
+                  type="text"
+                  value={imapHost}
+                  onChange={(e) => setImapHost(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label>IMAP 端口</label>
+                <input
+                  type="number"
+                  value={imapPort}
+                  onChange={(e) => setImapPort(parseInt(e.target.value))}
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="form-row">
+              <div className="form-group">
+                <label>SMTP 服务器</label>
+                <input
+                  type="text"
+                  value={smtpHost}
+                  onChange={(e) => setSmtpHost(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label>SMTP 端口</label>
+                <input
+                  type="number"
+                  value={smtpPort}
+                  onChange={(e) => setSmtpPort(parseInt(e.target.value))}
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="form-group">
+              <label>用户名</label>
+              <input
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="通常与邮箱地址相同"
+                required
+              />
+            </div>
+
+            <div className="form-group">
+              <label>密码 / 授权码</label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="邮箱密码或授权码"
+                required
+              />
+              <p className="hint">注意：QQ、163 等邮箱需要使用授权码而非登录密码</p>
+            </div>
+
+            <div className="form-actions">
+              <button type="submit" className="btn btn-primary" disabled={saving}>
+                {saving ? '保存中...' : '保存账户'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Email Messages */}
+      {selectedAccount && (
+        <div className="section">
+          <h2>邮件记录 - {selectedAccount.email}</h2>
+          
+          {loadingMessages ? (
+            <div className="loading">加载中...</div>
+          ) : messages.length === 0 ? (
+            <div className="empty-state">
+              <p>还没有同步过邮件</p>
+              <p className="hint">点击上方的"同步"按钮搜索账单和发票邮件</p>
+            </div>
+          ) : (
+            <div className="message-list">
+              {messages.map(msg => (
+                <div key={msg.id} className={`message-item ${msg.processed ? 'processed' : ''}`}>
+                  <div className="message-subject">{msg.subject || '(无主题)'}</div>
+                  <div className="message-meta">
+                    <span>From: {msg.from_address || '未知'}</span>
+                    {msg.date && <span>{new Date(msg.date).toLocaleString()}</span>}
+                  </div>
+                  <div className="message-status">
+                    {msg.processed ? '✓ 已处理' : '未处理'}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Help Section */}
+      <div className="section">
+        <h2>使用说明</h2>
+        <div className="help-content">
+          <h3>支持的邮箱</h3>
+          <p>支持所有支持 IMAP 协议的邮箱，包括：163、QQ、126、Gmail、Outlook 等。</p>
+          
+          <h3>授权码说明</h3>
+          <p>大多数现代邮箱需要使用授权码而非登录密码：</p>
+          <ul>
+            <li><strong>163/126 邮箱</strong>: 设置 → POP3/SMTP/IMAP → 开启 IMAP/SMTP → 获取授权码</li>
+            <li><strong>QQ 邮箱</strong>: 设置 → 账户 → POP3/IMAP/SMTP/Exchange 服务 → 开启 IMAP/SMTP → 获取授权码</li>
+            <li><strong>Gmail</strong>: 账户 → 安全性 → 应用密码或使用 OAuth</li>
+          </ul>
+          
+          <h3>搜索关键词</h3>
+          <p>系统会自动搜索包含以下关键词的邮件：账单、发票、bill、invoice、payment、消费</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -1778,3 +1778,219 @@ select {
     padding: 16px;
   }
 }
+
+/* ============================================
+   Email Settings Page
+   ============================================ */
+.email-settings .page-header {
+  margin-bottom: 24px;
+}
+
+.email-settings .page-header h1 {
+  margin-bottom: 4px;
+}
+
+.email-settings .subtitle {
+  color: var(--text-secondary);
+}
+
+.email-settings .section {
+  background: var(--bg-card);
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+  box-shadow: var(--shadow-sm);
+}
+
+.email-settings .section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.email-settings .section h2 {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.email-settings .section-header h2 {
+  margin-bottom: 0;
+}
+
+.email-settings .empty-state {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.email-settings .empty-state .hint {
+  color: var(--text-muted);
+  font-size: 13px;
+  margin-top: 8px;
+}
+
+.email-settings .account-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.email-settings .account-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  background: var(--bg-main);
+  border-radius: 8px;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.email-settings .account-card:hover {
+  border-color: var(--primary-light);
+}
+
+.email-settings .account-card.selected {
+  border-color: var(--primary);
+  background: var(--primary-light);
+}
+
+.email-settings .account-info {
+  flex: 1;
+}
+
+.email-settings .account-email {
+  font-weight: 600;
+  font-size: 15px;
+  margin-bottom: 4px;
+}
+
+.email-settings .account-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.email-settings .account-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.email-settings .form {
+  max-width: 600px;
+}
+
+.email-settings .form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.email-settings .form-group {
+  margin-bottom: 16px;
+}
+
+.email-settings .form-group label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 6px;
+  font-size: 14px;
+}
+
+.email-settings .form-group input,
+.email-settings .form-group select {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 14px;
+  transition: var(--transition);
+}
+
+.email-settings .form-group input:focus,
+.email-settings .form-group select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-light);
+}
+
+.email-settings .form-group .hint {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.email-settings .form-actions {
+  margin-top: 20px;
+}
+
+.email-settings .message-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.email-settings .message-item {
+  padding: 12px 16px;
+  background: var(--bg-main);
+  border-radius: 6px;
+}
+
+.email-settings .message-item.processed {
+  opacity: 0.7;
+}
+
+.email-settings .message-subject {
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.email-settings .message-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.email-settings .message-status {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.email-settings .help-content h3 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 16px 0 8px 0;
+  color: var(--text-primary);
+}
+
+.email-settings .help-content h3:first-child {
+  margin-top: 0;
+}
+
+.email-settings .help-content p {
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+  line-height: 1.5;
+}
+
+.email-settings .help-content ul {
+  margin-left: 20px;
+  color: var(--text-secondary);
+}
+
+.email-settings .help-content li {
+  margin-bottom: 4px;
+  line-height: 1.5;
+}
+
+.email-settings .loading {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-secondary);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -175,3 +175,44 @@ export interface SmartAssignmentApplyResult {
   skipped: number;
   results: SmartAssignmentResult[];
 }
+
+// Email types
+export interface EmailAccount {
+  id: string;
+  email: string;
+  imap_host: string;
+  imap_port: number;
+  smtp_host: string;
+  smtp_port: number;
+  username: string;
+  password: string;
+  last_sync?: string | null;
+  created_at: string;
+}
+
+export interface EmailAttachment {
+  filename: string;
+  contentType: string;
+  size: number;
+  path?: string;
+}
+
+export interface EmailMessage {
+  id: string;
+  account_id: string;
+  message_id: string;
+  subject?: string | null;
+  from_address?: string | null;
+  date?: string | null;
+  attachments?: string | null;
+  processed: number;
+  created_at: string;
+}
+
+export interface EmailSyncResult {
+  success: boolean;
+  emailsFound: number;
+  attachmentsDownloaded: number;
+  transactionsImported: number;
+  errors: string[];
+}


### PR DESCRIPTION
## 功能

自动从邮箱下载账单和发票附件。

### 实现
- email_accounts 表：存储邮箱配置
- email_messages 表：记录已处理的邮件
- IMAP 连接：支持 163、QQ、Gmail 等
- 关键词搜索：账单、发票、消费等
- 设置页面：添加/删除邮箱账户，手动同步

### 前端
- 导航栏 📧 邮箱设置
- 邮箱管理界面

### 测试
- npm test: 通过
- npm run build: 成功